### PR TITLE
glue implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > dev about Data Engineering stuff
 > 
 
-# 目次
+# Table of Contents
 - [:fire:dev2025-data-engineering:fire:](#firedev2025-data-engineeringfire)
-- [目次](#目次)
+- [Table of Contents](#table-of-contents)
 - [:fire:First Thing First](#firefirst-thing-first)
 - [:fire:Technology Selection](#firetechnology-selection)
   - [:fire:High-Level Design](#firehigh-level-design)

--- a/terraform/glue.tf
+++ b/terraform/glue.tf
@@ -1,0 +1,88 @@
+# -----------------------------------
+# Glue
+# -----------------------------------
+resource "aws_glue_workflow" "workflow" {
+  name = "workflow"
+}
+resource "aws_glue_catalog_database" "catalog" {
+  name = "catalogdatabase"
+
+  /* TODO Lake Formation
+  create_table_default_permission {
+    permissions = ["SELECT"]
+
+    principal {
+      data_lake_principal_identifier = "IAM_ALLOWED_PRINCIPALS"
+    }
+  }
+*/
+
+}
+resource "aws_glue_catalog_table" "catalog_table" {
+  name          = "catalogtable"
+  database_name = aws_glue_catalog_database.catalog.name
+
+  table_type = "EXTERNAL_TABLE"
+  parameters = {
+    EXTERNAL              = "TRUE"
+    "parquet.compression" = "SNAPPY"
+  }
+  partition_keys {
+    name = "partition_key"
+    type = "string"
+  }
+  storage_descriptor {
+    location      = "s3://private-admin-bucket-20250215/raw_data/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "parquet_serde"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+      parameters = {
+        "serialization.format" = 1
+      }
+    }
+    columns {
+      name = "user_id"
+      type = "int"
+    }
+    columns {
+      name = "first_name"
+      type = "string"
+    }
+    columns {
+      name = "last_name"
+      type = "string"
+    }
+    columns {
+      name    = "gender"
+      type    = "int"
+      comment = "0 means men. 1 means woman. 2 means other."
+    }
+    columns {
+      name    = "created_at"
+      type    = "date"
+      comment = "24-hour format"
+    }
+  }
+}
+resource "aws_glue_crawler" "crawler" {
+  database_name = aws_glue_catalog_database.catalog.name
+  name          = "crawler"
+  role          = aws_iam_role.glue_service_role.arn
+  # TODO iceberg_targetの設定を、後で実装するか含め確認
+
+  s3_target {
+    path        = "s3://${aws_s3_bucket.private_admin.bucket}/raw_data/"
+    sample_size = 10 # the number of files in each leaf folder to be crawled
+  }
+}
+resource "aws_glue_trigger" "raw_data_trigger" {
+  name = "raw_data_trigger"
+  type = "ON_DEMAND"
+
+  actions {
+    crawler_name = aws_glue_crawler.crawler.name
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,22 @@
+# -----------------------------------
+# IAM
+# -----------------------------------
+resource "aws_iam_role" "glue_service_role" {
+  name = "glue_service_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "glue.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "glue_service_role_attach" {
+  role       = aws_iam_role.glue_service_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -3,7 +3,8 @@
 # -----------------------------------
 # private bucket for admin use
 resource "aws_s3_bucket" "private_admin" {
-  bucket = "private-admin-bucket-20250215"
+  bucket        = "private-admin-bucket-20250215"
+  force_destroy = true # only for dev test
   tags = {
     Name = "private-admin-bucket-20250215"
   }
@@ -54,3 +55,23 @@ data "aws_iam_policy_document" "limited_access_only_private_admin" {
   }
 }
 */
+resource "aws_s3_object" "raw_data_day1" {
+  key    = "raw_data/partition_key=20250201/"
+  bucket = aws_s3_bucket.private_admin.id
+  source = ""
+}
+resource "aws_s3_object" "raw_data_day2" {
+  key    = "raw_data/partition_key=20250202/"
+  bucket = aws_s3_bucket.private_admin.id
+  source = ""
+}
+resource "aws_s3_object" "catalog_table" {
+  key    = "catalog_table/"
+  bucket = aws_s3_bucket.private_admin.id
+  source = ""
+}
+resource "aws_s3_object" "loaded_data" {
+  key    = "loaded_data/"
+  bucket = aws_s3_bucket.private_admin.id
+  source = ""
+}


### PR DESCRIPTION
Glue setup

# 主な作業内容

- IAM for Glue
- S3 for Glue
- Glue
   - workflow
   - Crawler
   - Catalog Database
   - partition key
   - trigger
- ETL job by Python(Apache Spark)
- created CSV demo Data
   - csv 1
      - 1,Miriam,Fleay,Agender,03-05-2024
   - csv 2
      - 2,Landaulet,2,06-02-2025

# Glue job実行手順

- terraform apply
- upload data to S3
   - py
      - s3://<my-bucket>/glue_etl.py
  -  csv
     - s3://＜my-bucket＞/raw_data/user/user_table_day1.csv
     - s3://＜my-bucket＞/raw_data/item/item_table_1.csv
- Run Glue Crawler
- Run ETL job "glue_job_etl"
- check S3 data
   - s3://＜my-bucket＞/loaded_data/


# Memo

- データは一時的にCSVでの入出力（データ確認用）。後にParquetにする
- CSVデータはヘッダー有り
- ハードコーディングしている部分が有り
- Query with S3 Select が成功しない点が不明